### PR TITLE
Added storage directory for Disk Implementation

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -38,6 +38,13 @@ but working with multiple threads.
  For a big scene with a lot of entities, a substancial amount of memory will be used to store those (limiting 
  the effectiveness of this implementation on loading huge scene with low amount of memory).
 
+ It is also possible to specify the path to the temporary file that will be used to store the octree data.
+ Especially with large scenes it is recommended to use a fast disk (SSD) with a lot of space available.<br>
+ The "Browse" button lets you change the storage directory. By default the system temporary directory is used. <br>
+ On Windows this is `C:\Users\<USERNAME>\AppData\Local\Temp`<br>
+ On Linux this is `/tmp`<br>
+ On MacOS this is `/var/folders/<random string>/T`
+
 ### Garbage-collected Implementation
 Available under the name `GC_PACKED`. This implementation is similar to the built-in `PACKED` implementation 
 with the difference that, instead of merging equal nodes after every insertion, merging is only done once in a while

--- a/src/main/java/dev/ferrand/chunky/octree/implementations/DiskOctree.java
+++ b/src/main/java/dev/ferrand/chunky/octree/implementations/DiskOctree.java
@@ -22,6 +22,8 @@ public class DiskOctree extends AbstractOctreeImplementation {
     private final int cacheSize = PersistentSettings.settings.getInt("disk.cacheSize", 11);
     private final int cacheNumber = PersistentSettings.settings.getInt("disk.cacheNumber", 2048);
 
+    private final String storageDirectory = PersistentSettings.settings.getString("disk.storageDirectory", null);
+
     private static final class NodeId implements Octree.NodeId {
         public long nodeIndex;
 
@@ -52,7 +54,12 @@ public class DiskOctree extends AbstractOctreeImplementation {
 
     public DiskOctree(int depth) throws IOException {
         this.depth = depth;
-        treeFile = File.createTempFile("disk-octree", ".bin");
+
+        if(storageDirectory == null)
+            treeFile = File.createTempFile("disk-octree", ".bin");
+        else
+            treeFile = File.createTempFile("disk-octree", ".bin", new File(storageDirectory));
+
         treeData = new SingleThreadReadWriteCache(treeFile, cacheSize, cacheNumber);
         setAt(0, 0);
         size = 1;

--- a/src/main/java/dev/ferrand/chunky/octree/ui/OctreeTab.java
+++ b/src/main/java/dev/ferrand/chunky/octree/ui/OctreeTab.java
@@ -4,15 +4,18 @@ import javafx.fxml.FXML;
 import javafx.fxml.FXMLLoader;
 import javafx.fxml.Initializable;
 import javafx.scene.Node;
+import javafx.scene.control.Button;
 import javafx.scene.control.ChoiceBox;
 import javafx.scene.control.ScrollPane;
 import javafx.scene.control.Tooltip;
+import javafx.stage.DirectoryChooser;
 import se.llbit.chunky.PersistentSettings;
 import se.llbit.chunky.renderer.scene.Scene;
 import se.llbit.chunky.ui.DoubleAdjuster;
 import se.llbit.chunky.ui.IntegerAdjuster;
 import se.llbit.chunky.ui.render.RenderControlsTab;
 
+import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.util.ArrayList;
@@ -58,6 +61,8 @@ public class OctreeTab extends ScrollPane implements RenderControlsTab, Initiali
 
     @FXML private DoubleAdjuster gcoctree_threshold;
 
+    @FXML private Button disk_storageDirectory;
+
     public OctreeTab() {
         try {
             FXMLLoader loader = new FXMLLoader(getClass().getResource("/octree-tab.fxml"));
@@ -97,6 +102,9 @@ public class OctreeTab extends ScrollPane implements RenderControlsTab, Initiali
             PersistentSettings.setIntOption("gcoctree.threshold", (int)(double)val);
             gcoctree_threshold.set((int)(double)val);
         });
+
+        disk_storageDirectory.setOnAction(event -> browseForDirectory());
+        disk_storageDirectory.setTooltip(new Tooltip("The directory where the octree will be stored. If not set, it will be stored in the default temporary-file directory."));
     }
 
     @Override
@@ -111,5 +119,23 @@ public class OctreeTab extends ScrollPane implements RenderControlsTab, Initiali
     @Override
     public Node getTabContent() {
         return this;
+    }
+
+    private void browseForDirectory() {
+        DirectoryChooser directoryChooser = new DirectoryChooser();
+        directoryChooser.setTitle("Choose Storage Directory");
+
+        String storageDirectory = PersistentSettings.settings.getString("disk.storageDirectory", null);
+        if(storageDirectory != null)
+            directoryChooser.setInitialDirectory(new File(storageDirectory));
+        else
+            directoryChooser.setInitialDirectory(new File(System.getProperty("java.io.tmpdir")));
+
+        File selectedDirectory = directoryChooser.showDialog(disk_storageDirectory.getScene().getWindow());
+        if(selectedDirectory == null)
+            return;
+
+        PersistentSettings.settings.setString("disk.storageDirectory", selectedDirectory.getAbsolutePath());
+        disk_storageDirectory.setText("Change");
     }
 }

--- a/src/main/resources/octree-tab.fxml
+++ b/src/main/resources/octree-tab.fxml
@@ -8,6 +8,7 @@
 <?import javafx.scene.control.ChoiceBox?>
 <?import javafx.scene.control.Label?>
 <?import se.llbit.chunky.ui.DoubleAdjuster?>
+<?import javafx.scene.control.Button?>
 <fx:root type="javafx.scene.control.ScrollPane" xmlns="http://javafx.com/javafx/10.0.1" xmlns:fx="http://javafx.com/fxml/1">
    <content>
       <VBox spacing="10.0">
@@ -28,6 +29,12 @@
                                      </children>
                                      </HBox>
                                      <IntegerAdjuster fx:id="disk_cacheNumber" alignment="CENTER" prefHeight="26.0" prefWidth="95.0"/>
+                                     <HBox alignment="CENTER_LEFT" spacing="10.0">
+                                         <children>
+                                             <Label text="Storage Directory:" />
+                                             <Button fx:id="disk_storageDirectory" mnemonicParsing="false" text="Browse"/>
+                                         </children>
+                                     </HBox>
                                  </children>
                                  <padding>
                                      <Insets top="5.0" />


### PR DESCRIPTION
This PR fixes #4 by adding a new button to the Advanced Octree Options in the Disk Implementation category.

By default the system temporary directory is still used. 
If you click the Browse Button you can select a different directory.
The directory will be saved in the settings, so next time you open chunky the new directory will still be used.

In the [Readme.md](https://github.com/aTom3333/chunky-octree-plugin/blob/master/Readme.md) a description was added to the Disk Implementation Specific instructions which explains that the storage directory is changeable and where the the octree files are stored by default (I had to search it the first time I used this plugin because I didn't know that the temp folder was used).

![image](https://github.com/aTom3333/chunky-octree-plugin/assets/66020920/39395819-e82c-4f18-b1d9-e12e58d7cf15)
